### PR TITLE
fixes failing tests

### DIFF
--- a/NSuperTest.Tests/Servers/ServerTests.cs
+++ b/NSuperTest.Tests/Servers/ServerTests.cs
@@ -21,7 +21,7 @@ namespace NSuperTest.Tests.Servers
             var testBuilder = server.Get("/");
 
             testBuilder.Should().NotBeNull();
-            testBuilder.Should().BeOfType<ITestBuilder>();
+            testBuilder.Should().BeAssignableTo<ITestBuilder>();
         }
 
         [Test]
@@ -33,7 +33,7 @@ namespace NSuperTest.Tests.Servers
             var testBuilder = server.Get("/");
 
             testBuilder.Should().NotBeNull();
-            testBuilder.Should().BeOfType<ITestBuilder>();
+            testBuilder.Should().BeAssignableTo<ITestBuilder>();
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace NSuperTest.Tests.Servers
             var testBuilder = server.Get("/");
 
             testBuilder.Should().NotBeNull();
-            testBuilder.Should().BeOfType<ITestBuilder>();
+            testBuilder.Should().BeAssignableTo<ITestBuilder>();
         }
     }
 }


### PR DESCRIPTION
Tests were failing because the tests were testing the exact type that was being returned, rather that checking if the returned type was assignable to the interface.