### PR TITLE
Current NuGet package (v0.1.21) not working for .NET 4.6.1

### DIFF
--- a/NSuperTest.Tests/NSuperTest.Tests.csproj
+++ b/NSuperTest.Tests/NSuperTest.Tests.csproj
@@ -70,18 +70,6 @@
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.Http.Owin, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -100,7 +88,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NSuperTest\NSuperTest.csproj">

--- a/NSuperTest.Tests/packages.config
+++ b/NSuperTest.Tests/packages.config
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="3.4.1" targetFramework="net451" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />
-  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net451" />
-  <package id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net451" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net451" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net451" />

--- a/NSuperTest/NSuperTest.csproj
+++ b/NSuperTest/NSuperTest.csproj
@@ -72,18 +72,6 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.Http.Owin, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -101,7 +89,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/NSuperTest/NSuperTest.nuspec
+++ b/NSuperTest/NSuperTest.nuspec
@@ -12,14 +12,19 @@
     <description>Super Test style testing for .net web api projects</description>
     <copyright>Copyright 2016</copyright>
     <dependencies>
-      <group targetFramework=".NETFramework4.0">
+      <group targetFramework="net451">
+        <dependency id="Microsoft.Owin" version="3.0.1" />
         <dependency id="Microsoft.Owin.Host.HttpListener" version="3.0.1" />
         <dependency id="Microsoft.Owin.Hosting" version="3.0.1" />
-        <dependency id="System.Net.Http" version="4.0.0" />
+        <dependency id="Newtonsoft.Json" version="6.0.8" />
+        <dependency id="Owin" version="1.0" />
       </group>
     </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System.Net.Http" targetFramework="net451" />
+    </frameworkAssemblies>
   </metadata>
   <files>
-    <file src="bin/Release/NSuperTest.dll" target="lib/NSuperTest.dll" />
+    <file src="bin/Release/NSuperTest.dll" target="lib/net451/NSuperTest.dll" />
   </files>
 </package>

--- a/NSuperTest/packages.config
+++ b/NSuperTest/packages.config
@@ -1,9 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />
-  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net451" />
-  <package id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net451" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net451" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net451" />


### PR DESCRIPTION
Had some trouble resulting in "System.IO.FileLoadException: Could not load file or assembly x". For me removing unused package dependencies and standardizing .nuspec helped this flow more smoothly with .NET 4.6.1. If I'm way off and these packages are indeed required then just ignore this pull request :-)